### PR TITLE
Optional fts

### DIFF
--- a/scripts/ddl.sql
+++ b/scripts/ddl.sql
@@ -1,5 +1,4 @@
 --postgresql CDM DDL Specification for OMOP Common Data Model 5.4
---(except that I've monkeyed about with it a bit)
 --HINT DISTRIBUTE ON KEY (person_id)
 CREATE TABLE @cdmDatabaseSchema.person (
 			person_id integer NOT NULL,
@@ -418,7 +417,6 @@ CREATE TABLE @cdmDatabaseSchema.cdm_source (
 CREATE TABLE @cdmDatabaseSchema.concept (
 			concept_id integer NOT NULL,
 			concept_name varchar(255) NOT NULL,
-      concept_fts tsvector GENERATED ALWAYS AS (to_tsvector('english', concept_name)) STORED,
 			domain_id varchar(20) NOT NULL,
 			vocabulary_id varchar(20) NOT NULL,
 			concept_class_id varchar(20) NOT NULL,

--- a/scripts/fts.sql
+++ b/scripts/fts.sql
@@ -1,0 +1,7 @@
+--Full text search column
+ALTER TABLE @cdmDatabaseSchema.concept
+  ADD COLUMN concept_name_tsv tsvector
+  GENERATED ALWAYS AS (to_tsvector('english', concept_name)) STORED;
+--Full text search index
+CREATE INDEX idx_concept_fts ON @cdmDatabaseSchema.concept USING GIN (concept_fts);
+

--- a/scripts/indices.sql
+++ b/scripts/indices.sql
@@ -122,8 +122,6 @@ CREATE INDEX idx_source_to_concept_map_c ON @cdmDatabaseSchema.source_to_concept
 CREATE INDEX idx_drug_strength_id_1  ON @cdmDatabaseSchema.drug_strength  (drug_concept_id ASC);
 CLUSTER @cdmDatabaseSchema.drug_strength  USING idx_drug_strength_id_1 ;
 CREATE INDEX idx_drug_strength_id_2 ON @cdmDatabaseSchema.drug_strength (ingredient_concept_id ASC);
---Additional full text search index
-CREATE INDEX idx_concept_fts ON @cdmDatabaseSchema.concept USING GIN (concept_fts);
 --Additional v6.0 indices
 --CREATE CLUSTERED INDEX idx_survey_person_id_1 ON @cdmDatabaseSchema.survey_conduct (person_id ASC);
 --CREATE CLUSTERED INDEX idx_episode_person_id_1 ON @cdmDatabaseSchema.episode (person_id ASC);

--- a/setup.sh
+++ b/setup.sh
@@ -8,6 +8,7 @@ DB_PASSWORD="$DB_PASSWORD"
 DB_NAME="$DB_NAME"
 VOCAB_DATA_DIR="$VOCAB_DATA_DIR"
 SCHEMA_NAME="$SCHEMA_NAME"
+FTS_CREATE="$FTS_CREATE"
 
 # SQL files
 sql_files=(primary-keys.sql constraints.sql indices.sql)
@@ -61,3 +62,13 @@ for sql_file in "${sql_files[@]}"; do
 done
 
 echo "OMOP CDM creation finished."
+
+if [ "$FTS_CREATE" ]; then
+  echo "Adding full-text search on concept table"
+  input_file="${script_dir}/fts.sql"
+  temp_file="${temp_dir}/temp_fts.sql"
+
+  sed "s/@cdmDatabaseSchema/${SCHEMA_NAME}/g" "$input_file" > "$temp_file"
+  PGPASSWORD="$DB_PASSWORD" psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" -f "$temp_file"
+  rm "$temp_file"
+fi


### PR DESCRIPTION
This makes the full-text search optional
- fts.sql script contains the full-text search sql
- setup.sh only executes fts.sql if FTS_CREATE is true in the environment
